### PR TITLE
fixed override of FlutterAppAuthPlatform class method of browser closing

### DIFF
--- a/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
@@ -82,4 +82,9 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
     }
     return EndSessionResponse(result['state']);
   }
+
+  @override
+  Future<void> closeBrowser() async {
+    return _channel.invokeMethod('closeBrowser');
+  }
 }


### PR DESCRIPTION
fixed override of FlutterAppAuthPlatform class method of browser closing